### PR TITLE
Update outdated dependencies and Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/risoflora/wethr"
 readme = "README.md"
 keywords = ["celsius", "fahrenheit", "temperature", "weather"]
 categories = ["command-line-utilities", "network-programming"]
-edition = "2018"
+edition = "2021"
 
 [profile.release]
 lto = true
@@ -18,16 +18,16 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "2.0"
 anyhow = "1.0"
 getopts = "0.2"
 tokio = { version = "1", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "gzip",
     "json",
 ] }
-indicatif = "0.16"
+indicatif = "0.17"
 humantime = "2.1"

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -46,7 +46,7 @@ pub struct Spinner {
 impl Spinner {
     pub fn new() -> Self {
         Spinner {
-            progress_bar: ProgressBar::with_draw_target(!0, ProgressDrawTarget::stdout()),
+            progress_bar: ProgressBar::with_draw_target(None, ProgressDrawTarget::stdout()),
             silent: false,
         }
     }
@@ -65,7 +65,8 @@ impl Spinner {
             self.progress_bar.set_style(
                 ProgressStyle::default_spinner()
                     .tick_strings(TICK_STRINGS)
-                    .template(&Self::format_tpl(color)),
+                    .template(&Self::format_tpl(color))
+                    .unwrap(),
             );
         }
         self


### PR DESCRIPTION
## Summary

- Bump Rust edition from 2018 to 2021
- Update **reqwest** from 0.11 to 0.12 (API compatible — uses `.get()`, `.send()`, `.json()`)
- Update **indicatif** from 0.16 to 0.17 with required API adjustments:
  - `ProgressBar::with_draw_target(!0, ...)` → `ProgressBar::with_draw_target(None, ...)` (`u64` → `Option<u64>`)
  - `.template(&str)` → `.template(&str).unwrap()` (returns `Result` in 0.17)
- Update **thiserror** from 1.0 to 2.0 (compatible — only uses `#[error(transparent)]`)

Closes #11

## Test plan

- [x] `cargo check` passes
- [x] 26/27 tests pass — the one failure (`location_client_get_by_query`) is a pre-existing flaky network test that also fails on `main`